### PR TITLE
Add command chaining

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -62,6 +62,8 @@ CinnamonBun is a **desktop app for managing contacts, optimized for use via a Co
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
+* Multiple commands can be chained by separating each command with the '|' character. Each command is run sequentially from first to last. Invalid commands and special commands `help` and `exit` will break the chain and stop further command execution.<br>
+  e.g `add n/John Doe e/johndoe@email.com | edit 5 p/999 | delete 2`
 </div>
 
 ### Viewing help : `help`

--- a/docs/team/danemarc.md
+++ b/docs/team/danemarc.md
@@ -15,11 +15,13 @@ Given below are my contributions to the project.
   * To be added soon
 
 * **Enhancements to existing features**:
-  * Expanded the find feature (Pull request [\#1]())
+  * Expanded the find feature to include all Person attributes (Pull request [\#7](https://github.com/AY2122S2-CS2103T-W09-2/tp/pull/7))
+  * Added the ability to issue multiple commands in a single line (Pull request [\#35](https://github.com/AY2122S2-CS2103T-W09-2/tp/pull/35))
 
 * **Documentation**:
   * User Guide:
-    * Added documentation for the `find` feature [\#1]()
+    * Added documentation for the `find` feature [\#7](https://github.com/AY2122S2-CS2103T-W09-2/tp/pull/7)
+    * Added documentation for command chaining [\#35](https://github.com/AY2122S2-CS2103T-W09-2/tp/pull/35)
   * Developer Guide:
     * Added implementation details of the `find` feature
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -38,17 +38,27 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
-        logger.info("----------------[USER COMMAND][" + commandText + "]");
+    public CommandResult execute(String userInput) throws CommandException, ParseException {
+        logger.info("----------------[USER INPUT][" + userInput + "]");
 
-        CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
-        commandResult = command.execute(model);
+        CommandResult commandResult = null;
+        String[] commands = userInput.split("\\|");
 
-        try {
-            storage.saveAddressBook(model.getAddressBook());
-        } catch (IOException ioe) {
-            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+        for (String commandText : commands) {
+            logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+            Command command = addressBookParser.parseCommand(commandText);
+            commandResult = command.execute(model);
+
+            try {
+                storage.saveAddressBook(model.getAddressBook());
+            } catch (IOException ioe) {
+                throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+            }
+
+            if (commandResult.isExit() || commandResult.isShowHelp()) {
+                break;
+            }
         }
 
         return commandResult;


### PR DESCRIPTION
Fixes #34 

Adds the ability to chain commands in a single line by separating each command with the '|' delimiter
E.g. `edit 4 p/81234567 | delete 3 | edit 1 n/Bob`

Only the feedback/result of the last command will be shown to the user

Special commands such as `help` and `exit` will break the chain and execute immediately

Invalid commands will also break the chain but preceding commands will still execute properly
