### PR TITLE
Sort command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandRegistry.java
+++ b/src/main/java/seedu/address/logic/commands/CommandRegistry.java
@@ -10,6 +10,7 @@ import seedu.address.logic.parser.EditCommandParser;
 import seedu.address.logic.parser.FindCommandParser;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.RemarkCommandParser;
+import seedu.address.logic.parser.SortCommandParser;
 
 public class CommandRegistry {
     public static final Map<String, Parser<? extends Command>> PARSERS;
@@ -27,6 +28,7 @@ public class CommandRegistry {
         parsers.put(HelpCommand.COMMAND_WORD, (String args) -> new HelpCommand());
         parsers.put(DeleteFilteredCommand.COMMAND_WORD, (String args) -> new DeleteFilteredCommand());
         parsers.put(RemarkCommand.COMMAND_WORD, new RemarkCommandParser());
+        parsers.put(SortCommand.COMMAND_WORD, new SortCommandParser());
 
         // --- Do not modify below this line unless you know what you're doing. (Trust me, you don't.) ---
         PARSERS = Collections.unmodifiableMap(parsers);

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -11,8 +11,14 @@ import java.util.Optional;
 
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Field;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Remark;
+import seedu.address.model.tag.Tag;
 
 /**
  * Sorts the person list in address book based on fields given.
@@ -20,6 +26,18 @@ import seedu.address.model.person.Person;
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     public static final String MESSAGE_SUCCESS = "List is sorted accordingly!";
+    public static final String DESCENDING_KEYWORD = "desc";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": sorts the person list in the field order specified.\n"
+            + "Parameters: Any field prefix "
+            + "[" + Name.PREFIX + "] "
+            + "[" + Phone.PREFIX + "] "
+            + "[" + Email.PREFIX + "] "
+            + "[" + Address.PREFIX + "] "
+            + "[" + Remark.PREFIX + "] "
+            + "[" + Tag.PREFIX + "]...\n"
+            + "Add keyword" + DESCENDING_KEYWORD + " after a field if it's to be sorted in descending order.\n"
+            + "Example: " + COMMAND_WORD + " n/ e/ desc a/ n/";
 
     private final List<FieldSortOrder> fieldSortOrderList;
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,81 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.person.Field;
+import seedu.address.model.person.Person;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class SortCommand extends Command {
+    public static final String COMMAND_WORD = "sort";
+    private final List<FieldSortOrder> fieldSortOrderList;
+
+    public static class FieldSortOrder {
+        private final Prefix fieldPrefix;
+        private final boolean isDescendingOrder;
+
+        public FieldSortOrder(Prefix fieldPrefix, boolean isDescendingOrder) {
+            this.fieldPrefix = fieldPrefix;
+            this.isDescendingOrder = isDescendingOrder;
+        }
+
+        public Prefix getFieldPrefix() {
+            return fieldPrefix;
+        }
+
+        public boolean getIsDescendingOrder() {
+            return isDescendingOrder;
+        }
+    }
+
+
+    public SortCommand(List<FieldSortOrder> fieldSortOrderList) {
+        requireNonNull(fieldSortOrderList);
+
+        this.fieldSortOrderList = fieldSortOrderList;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        for (FieldSortOrder fieldSortOrder : fieldSortOrderList) {
+            Comparator<Person> comparator = getComparator(fieldSortOrder.getFieldPrefix());
+            //grab the list, and sort them based on the order
+            //get field, in place sort
+            if (fieldSortOrder.getIsDescendingOrder()) {
+                comparator = comparator.reversed();
+            }
+
+            model.sortPersonList(comparator);
+        }
+
+        return null;
+        //return new CommandResult();
+        //model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        //return new CommandResult();
+    }
+
+    private Comparator<Person> getComparator(Prefix fieldPrefix) {
+        return (p1, p2) -> {
+            Optional<Field> p1Field = p1.getField(fieldPrefix);
+            Optional<Field> p2Field = p2.getField(fieldPrefix);
+
+            //null values would be the last in list in ascending order
+            if (p1Field.isEmpty() && p2Field.isEmpty()) {
+                return 0;
+            } else if (p1Field.isEmpty() && p2Field.isPresent()) {
+                return 1;
+            } else if (p1Field.isPresent() && p2Field.isEmpty()) {
+                return -1;
+            }
+
+            return p1Field.get().getValue().compareTo(p2Field.get().getValue());
+        };
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,46 +1,27 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.parser.Prefix;
-import seedu.address.model.Model;
-import seedu.address.model.person.Field;
-import seedu.address.model.person.Person;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.person.Field;
+import seedu.address.model.person.Person;
 
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
-    private final List<FieldSortOrder> fieldSortOrderList;
-
     public static final String MESSAGE_SUCCESS = "List is sorted accordingly!";
 
-    public static class FieldSortOrder {
-        private final Prefix fieldPrefix;
-        private final boolean isDescendingOrder;
-
-        public FieldSortOrder(Prefix fieldPrefix, boolean isDescendingOrder) {
-            this.fieldPrefix = fieldPrefix;
-            this.isDescendingOrder = isDescendingOrder;
-        }
-
-        public Prefix getFieldPrefix() {
-            return fieldPrefix;
-        }
-
-        public boolean getIsDescendingOrder() {
-            return isDescendingOrder;
-        }
-    }
-
+    private final List<FieldSortOrder> fieldSortOrderList;
 
     public SortCommand(List<FieldSortOrder> fieldSortOrderList) {
         requireNonNull(fieldSortOrderList);
-
         this.fieldSortOrderList = fieldSortOrderList;
     }
 
@@ -61,8 +42,8 @@ public class SortCommand extends Command {
                 comparator = comparator.thenComparing(currComperator);
             }
         }
-        model.sortPersonList(comparator);
 
+        model.sortPersonList(comparator);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
@@ -87,4 +68,25 @@ public class SortCommand extends Command {
             return p1Value.compareTo(p2Value);
         };
     }
+
+    public static class FieldSortOrder {
+        private final Prefix fieldPrefix;
+        private final boolean isDescendingOrder;
+
+        public FieldSortOrder(Prefix fieldPrefix, boolean isDescendingOrder) {
+            requireAllNonNull(fieldPrefix, isDescendingOrder);
+
+            this.fieldPrefix = fieldPrefix;
+            this.isDescendingOrder = isDescendingOrder;
+        }
+
+        public Prefix getFieldPrefix() {
+            return fieldPrefix;
+        }
+
+        public boolean getIsDescendingOrder() {
+            return isDescendingOrder;
+        }
+    }
 }
+

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -48,14 +48,20 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
+        Comparator<Person> comparator = null;
         for (FieldSortOrder fieldSortOrder : fieldSortOrderList) {
-            Comparator<Person> comparator = getComparator(fieldSortOrder.getFieldPrefix());
+            Comparator<Person> currComperator = getComparator(fieldSortOrder.getFieldPrefix());
             if (fieldSortOrder.getIsDescendingOrder()) {
-                comparator = comparator.reversed();
+                currComperator = currComperator.reversed();
             }
 
-            model.sortPersonList(comparator);
+            if (comparator == null) {
+                comparator = currComperator;
+            } else {
+                comparator = comparator.thenComparing(currComperator);
+            }
         }
+        model.sortPersonList(comparator);
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -14,17 +14,30 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Field;
 import seedu.address.model.person.Person;
 
+/**
+ * Sorts the person list in address book based on fields given.
+ */
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     public static final String MESSAGE_SUCCESS = "List is sorted accordingly!";
 
     private final List<FieldSortOrder> fieldSortOrderList;
 
+    /**
+     *  Creates a SortCommand to sort the person list in address book based on fields given.
+     * @param fieldSortOrderList a list of information about the fields to be sorted in the order of the list.
+     */
     public SortCommand(List<FieldSortOrder> fieldSortOrderList) {
         requireNonNull(fieldSortOrderList);
         this.fieldSortOrderList = fieldSortOrderList;
     }
 
+    /**
+     * Sorts the person list based on fields and information provided.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return CommandResult stating whether it has been successful.
+     */
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
@@ -48,6 +61,12 @@ public class SortCommand extends Command {
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
+    /**
+     * Get Comparator lambda function on how the people are to be sorted based on certain fields.
+     *
+     * @param fieldPrefix the field to be sorted by
+     * @return Comparator lambda function.
+     */
     private Comparator<Person> getComparator(Prefix fieldPrefix) {
         return (p1, p2) -> {
             Optional<Field> p1Field = p1.getField(fieldPrefix);
@@ -69,10 +88,19 @@ public class SortCommand extends Command {
         };
     }
 
+    /**
+     * Stores the details on how a field is to be sorted.
+     */
     public static class FieldSortOrder {
         private final Prefix fieldPrefix;
         private final boolean isDescendingOrder;
 
+        /**
+         * Constructor of FieldSortOrder.
+         *
+         * @param fieldPrefix the field.
+         * @param isDescendingOrder whether the field should be sorted in descending order.
+         */
         public FieldSortOrder(Prefix fieldPrefix, boolean isDescendingOrder) {
             requireAllNonNull(fieldPrefix, isDescendingOrder);
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -7,13 +7,17 @@ import seedu.address.model.person.Person;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     private final List<FieldSortOrder> fieldSortOrderList;
+
+    public static final String MESSAGE_SUCCESS = "List is sorted accordingly!";
 
     public static class FieldSortOrder {
         private final Prefix fieldPrefix;
@@ -46,8 +50,6 @@ public class SortCommand extends Command {
 
         for (FieldSortOrder fieldSortOrder : fieldSortOrderList) {
             Comparator<Person> comparator = getComparator(fieldSortOrder.getFieldPrefix());
-            //grab the list, and sort them based on the order
-            //get field, in place sort
             if (fieldSortOrder.getIsDescendingOrder()) {
                 comparator = comparator.reversed();
             }
@@ -55,10 +57,8 @@ public class SortCommand extends Command {
             model.sortPersonList(comparator);
         }
 
-        return null;
-        //return new CommandResult();
-        //model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        //return new CommandResult();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 
     private Comparator<Person> getComparator(Prefix fieldPrefix) {
@@ -75,7 +75,10 @@ public class SortCommand extends Command {
                 return -1;
             }
 
-            return p1Field.get().getValue().compareTo(p2Field.get().getValue());
+            String p1Value = p1Field.get().getValue().toLowerCase(Locale.ROOT);
+            String p2Value = p2Field.get().getValue().toLowerCase(Locale.ROOT);
+
+            return p1Value.compareTo(p2Value);
         };
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,21 +1,16 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FieldRegistry;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
 
 public class SortCommandParser implements Parser<SortCommand> {
     @Override
@@ -23,7 +18,8 @@ public class SortCommandParser implements Parser<SortCommand> {
         requireNonNull(args);
 
         Prefix[] allPrefixes = Arrays.copyOf(FieldRegistry.PREFIXES, FieldRegistry.PREFIXES.length);
-        Map<String, Prefix> prefixMap = Arrays.stream(allPrefixes).collect(Collectors.toMap(Prefix::getPrefix, prefix -> prefix));
+        Map<String, Prefix> prefixMap = Arrays.stream(allPrefixes)
+                .collect(Collectors.toMap(Prefix::getPrefix, prefix -> prefix));
         String delimiters = "\\s|((?=" + Arrays.stream(allPrefixes).map(Prefix::getPrefix).collect(
                 Collectors.joining("))|((?=")) + "))";
 
@@ -31,7 +27,7 @@ public class SortCommandParser implements Parser<SortCommand> {
         return new SortCommand(getFieldSortOrderList(values, prefixMap));
     }
 
-    private  List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] values, Map<String, Prefix> prefixMap) {
+    private List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] values, Map<String, Prefix> prefixMap) {
         List<SortCommand.FieldSortOrder> fieldSortOrderList = new ArrayList<SortCommand.FieldSortOrder>();
 
         for (int i = 0; i < values.length; ++i) {

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +23,7 @@ public class SortCommandParser implements Parser<SortCommand> {
      *
      * @param args Arguments for sorting.
      * @return SortCommand object for execution.
-     * @throws ParseException
+     * @throws ParseException if there is invalid input or arguments given are empty.
      */
     @Override
     public SortCommand parse(String args) throws ParseException {
@@ -45,7 +46,8 @@ public class SortCommandParser implements Parser<SortCommand> {
      * @param prefixMap hashmap on the prefix and it's corresponding object.
      * @return list on how the fields should be sorted based on the arguments provided.
      */
-    private List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] arguments, Map<String, Prefix> prefixMap) {
+    private List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] arguments, Map<String, Prefix> prefixMap)
+            throws ParseException {
         List<SortCommand.FieldSortOrder> fieldSortOrderList = new ArrayList<SortCommand.FieldSortOrder>();
 
         for (int i = 0; i < arguments.length; ++i) {
@@ -53,17 +55,20 @@ public class SortCommandParser implements Parser<SortCommand> {
                 continue;
             }
 
-            if (!prefixMap.containsKey(arguments[i])) {
-                //TODO:: SHOW ERROR
-                continue;
+            if (!prefixMap.containsKey(arguments[i]) && !arguments[i].equals(SortCommand.DESCENDING_KEYWORD)) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
             }
 
             boolean isDescending = false;
             if (i + 1 < arguments.length) {
-                isDescending = arguments[i + 1].equals("desc");
+                isDescending = arguments[i + 1].equals(SortCommand.DESCENDING_KEYWORD);
             }
 
             fieldSortOrderList.add(new SortCommand.FieldSortOrder(prefixMap.get(arguments[i]), isDescending));
+        }
+
+        if (fieldSortOrderList.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         return fieldSortOrderList;

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -24,8 +24,8 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         Prefix[] allPrefixes = Arrays.copyOf(FieldRegistry.PREFIXES, FieldRegistry.PREFIXES.length);
         Map<String, Prefix> prefixMap = Arrays.stream(allPrefixes).collect(Collectors.toMap(Prefix::getPrefix, prefix -> prefix));
-        String delimiters = "\\s|" + Arrays.stream(allPrefixes).map(Prefix::getPrefix).collect(
-                Collectors.joining("|"));
+        String delimiters = "\\s|((?=" + Arrays.stream(allPrefixes).map(Prefix::getPrefix).collect(
+                Collectors.joining("))|((?=")) + "))";
 
         String[] values = args.split(delimiters);
         return new SortCommand(getFieldSortOrderList(values, prefixMap));
@@ -34,15 +34,21 @@ public class SortCommandParser implements Parser<SortCommand> {
     private  List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] values, Map<String, Prefix> prefixMap) {
         List<SortCommand.FieldSortOrder> fieldSortOrderList = new ArrayList<SortCommand.FieldSortOrder>();
 
-        for (int i = 1; i < values.length; ++i) {
+        for (int i = 0; i < values.length; ++i) {
+            if (values[i].equals("")) {
+                continue;
+            }
+
             if (!prefixMap.containsKey(values[i])) {
-                //TODO:: throw error here that this delimiter doesnt exist
+                continue;
             }
 
             boolean isDescending = false;
             if (i + 1 < values.length) {
-                isDescending = values[i].equals("desc");
+                isDescending = values[i + 1].equals("desc");
             }
+
+            Prefix prefixTest = prefixMap.get(values[i]);
 
             fieldSortOrderList.add(new SortCommand.FieldSortOrder(prefixMap.get(values[i]), isDescending));
         }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -12,7 +12,18 @@ import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FieldRegistry;
 
+/**
+ * Parses user input for sorting the person list in address book.
+ */
 public class SortCommandParser implements Parser<SortCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns a SortCommand object for execution.
+     *
+     * @param args Arguments for sorting.
+     * @return SortCommand object for execution.
+     * @throws ParseException
+     */
     @Override
     public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -23,30 +34,36 @@ public class SortCommandParser implements Parser<SortCommand> {
         String delimiters = "\\s|((?=" + Arrays.stream(allPrefixes).map(Prefix::getPrefix).collect(
                 Collectors.joining("))|((?=")) + "))";
 
-        String[] values = args.split(delimiters);
-        return new SortCommand(getFieldSortOrderList(values, prefixMap));
+        String[] arguments = args.split(delimiters);
+        return new SortCommand(getFieldSortOrderList(arguments, prefixMap));
     }
 
-    private List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] values, Map<String, Prefix> prefixMap) {
+    /**
+     * Gets the list on how the fields should be sorted based on the arguments provided.
+     *
+     * @param arguments information split in proper format based on what the user input.
+     * @param prefixMap hashmap on the prefix and it's corresponding object.
+     * @return list on how the fields should be sorted based on the arguments provided.
+     */
+    private List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] arguments, Map<String, Prefix> prefixMap) {
         List<SortCommand.FieldSortOrder> fieldSortOrderList = new ArrayList<SortCommand.FieldSortOrder>();
 
-        for (int i = 0; i < values.length; ++i) {
-            if (values[i].equals("")) {
+        for (int i = 0; i < arguments.length; ++i) {
+            if (arguments[i].equals("")) {
                 continue;
             }
 
-            if (!prefixMap.containsKey(values[i])) {
+            if (!prefixMap.containsKey(arguments[i])) {
+                //TODO:: SHOW ERROR
                 continue;
             }
 
             boolean isDescending = false;
-            if (i + 1 < values.length) {
-                isDescending = values[i + 1].equals("desc");
+            if (i + 1 < arguments.length) {
+                isDescending = arguments[i + 1].equals("desc");
             }
 
-            Prefix prefixTest = prefixMap.get(values[i]);
-
-            fieldSortOrderList.add(new SortCommand.FieldSortOrder(prefixMap.get(values[i]), isDescending));
+            fieldSortOrderList.add(new SortCommand.FieldSortOrder(prefixMap.get(arguments[i]), isDescending));
         }
 
         return fieldSortOrderList;

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.FieldRegistry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+public class SortCommandParser implements Parser<SortCommand> {
+    @Override
+    public SortCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        Prefix[] allPrefixes = Arrays.copyOf(FieldRegistry.PREFIXES, FieldRegistry.PREFIXES.length);
+        Map<String, Prefix> prefixMap = Arrays.stream(allPrefixes).collect(Collectors.toMap(Prefix::getPrefix, prefix -> prefix));
+        String delimiters = "\\s|" + Arrays.stream(allPrefixes).map(Prefix::getPrefix).collect(
+                Collectors.joining("|"));
+
+        String[] values = args.split(delimiters);
+        return new SortCommand(getFieldSortOrderList(values, prefixMap));
+    }
+
+    private  List<SortCommand.FieldSortOrder> getFieldSortOrderList(String[] values, Map<String, Prefix> prefixMap) {
+        List<SortCommand.FieldSortOrder> fieldSortOrderList = new ArrayList<SortCommand.FieldSortOrder>();
+
+        for (int i = 1; i < values.length; ++i) {
+            if (!prefixMap.containsKey(values[i])) {
+                //TODO:: throw error here that this delimiter doesnt exist
+            }
+
+            boolean isDescending = false;
+            if (i + 1 < values.length) {
+                isDescending = values[i].equals("desc");
+            }
+
+            fieldSortOrderList.add(new SortCommand.FieldSortOrder(prefixMap.get(values[i]), isDescending));
+        }
+
+        return fieldSortOrderList;
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -92,6 +93,10 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    public void sortPersonList(Comparator<Person> comperator) {
+        persons.sortPersonList(comperator);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -95,8 +95,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
-    public void sortPersonList(Comparator<Person> comperator) {
-        persons.sortPersonList(comperator);
+    /**
+     * Sorts the person list based on the comparator provided.
+     *
+     * @param comparator use to sort the person list.
+     */
+    public void sortPersonList(Comparator<Person> comparator) {
+        persons.sortPersonList(comparator);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -84,4 +85,12 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Sorts the person list based on {@code comparator} given.
+     *
+     * @param comparator {@code comparator} to sort the person list by.
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void sortPersonList(Comparator<Person> comparator);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -10,7 +10,6 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
-import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -132,7 +132,6 @@ public class ModelManager implements Model {
     @Override
     public void sortPersonList(Comparator<Person> comparator) {
         requireNonNull(comparator);
-
         addressBook.sortPersonList(comparator);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,7 +24,6 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    //private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -133,7 +132,9 @@ public class ModelManager implements Model {
 
     @Override
     public void sortPersonList(Comparator<Person> comparator) {
+        requireNonNull(comparator);
 
+        addressBook.sortPersonList(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,11 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -22,6 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    //private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -126,6 +129,11 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void sortPersonList(Comparator<Person> comparator) {
+
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,9 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -95,6 +98,10 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+    }
+
+    public void sortPersonList(Comparator<Person> comperator) {
+        internalList.sort(comperator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -145,6 +146,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Create a sort command for CinnamonBun.

Users are able to sort the person list. By default, it'll be sorted in the specified field's ascending order unless explicitly stated otherwise in the command. 

Users should be able to chain it multiple times, including sorting repeated fields typed in the command.

Command: `sort [prefix] [desc]`

Example:
`sort n/ e/ desc` which means sort by name in ascending order first, followed by email in descending order. People with same names will be sorted by their email.