### PR TITLE
Fix userguide to address issue #184 and other possible issues

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,6 +80,12 @@ Commands in CinnamonBun can be broken down into several components.
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+* Any invalid parameters for commands will be regarded as part of the value of the preceding parameter. For example:
+  * In `addTransaction 1 a/123 td/2020-11-11 n/this is a note --not paid`, `--not paid` will be regarded 
+  as part of the note `n/this is a note --not paid` since `--not paid` is not a valid attribute. 
+  * In `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/vendor c/not a prefix t/owesMoney`, 
+  `c/not a prefix` will be regarded as part of the preceding tag `t/vendor c/not a prefix` since `c/not a prefix` is 
+  not a valid attribute/prefix.
 
 </div>
 


### PR DESCRIPTION
Resolves #184 by adding some details in UserGuide.md.

### Why change the user guide?

Just realized that this kind of issue appear also in other commands. For example:
`add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/vendor t/owesMoney c/not a prefix `

The app will throw an error message about invalid tag instead of invalid prefix (which was not implemented in the first place), hence the changes.

<img width="992" alt="Screenshot 2022-04-06 at 3 55 11 AM" src="https://user-images.githubusercontent.com/63901710/161838420-57d4f08f-c78f-4c38-b5ee-21394fe6575e.png">



